### PR TITLE
Fix for dev stringr

### DIFF
--- a/R/find_icon.R
+++ b/R/find_icon.R
@@ -21,6 +21,6 @@
 #' \url{https://github.com/tailwindlabs/heroicons}
 #'
 #' @export
-find_icons <- function(query = "") {
+find_icons <- function(query = ".") {
   stringr::str_subset(string = names(rheroicons), pattern = query)
 }


### PR DESCRIPTION
`str_detect(x, pattern = "")` now returns an error because it was effectively equivalent to `x != ""` when you could equally expect it to match nothing. I made the simplest change to your code to get your package working which is to instead use a pattern that will always match.